### PR TITLE
DROOLS-7020 Update jbang catalog deps to fixed ver

### DIFF
--- a/dmn.java
+++ b/dmn.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 11+
-//DEPS org.kie:kie-dmn-core:RELEASE
+//DEPS org.kie:kie-dmn-core:7.71.0.Final
 //DEPS info.picocli:picocli:4.2.0
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 //DEPS org.slf4j:slf4j-simple:1.7.30

--- a/feel.java
+++ b/feel.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 11+
-//DEPS org.kie:kie-dmn-feel:RELEASE
+//DEPS org.kie:kie-dmn-feel:7.71.0.Final
 //DEPS info.picocli:picocli:4.2.0
 //DEPS org.slf4j:slf4j-simple:1.7.30
 

--- a/xls2dmn.java
+++ b/xls2dmn.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 11+
-//DEPS org.kie:kie-dmn-xls2dmn-cli:RELEASE
+//DEPS org.kie:kie-dmn-xls2dmn-cli:7.71.0.Final
 //DEPS info.picocli:picocli:4.2.0
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.10.5.1
 //DEPS org.slf4j:slf4j-simple:1.7.30


### PR DESCRIPTION
Since Drools published version 8.x versions on Maven Central,
they are assumed to be the most up-to-date RELEASE
(regardless of the .Beta postfix).

As a consequence, tests are failing on non-cached resolutions.

At this point, is better to just fix an arbitrary 7.x .Final version
for the command line utilities.